### PR TITLE
Replace Magento json serialized interface with standard php json_decode

### DIFF
--- a/Model/Extension.php
+++ b/Model/Extension.php
@@ -37,31 +37,23 @@ class Extension
     private $cache;
 
     /**
-     * @var mixed
-     */
-    private $serializer;
-
-    /**
      * Extension constructor.
      * @param DataObjectFactory $dataObjectFactory
      * @param ZendClientFactory $httpClientFactory
      * @param CacheInterface $cache
-     * @param Json|null $serializer
      */
     public function __construct(
         DataObjectFactory $dataObjectFactory,
         ZendClientFactory $httpClientFactory,
-        CacheInterface $cache,
-        Json $serializer = null
+        CacheInterface $cache
     ) {
         $this->dataObjectFactory = $dataObjectFactory;
         $this->httpClientFactory = $httpClientFactory;
         $this->cache = $cache;
-        $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
     }
 
     /**
-     * Return extension info
+     *
      * @param string $moduleName
      * @return \Magento\Framework\DataObject
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -72,7 +64,6 @@ class Extension
         $data = $this->getServiceRequest($moduleName);
 
         $object = $this->dataObjectFactory->create();
-
         $object->addData($data);
 
         return $object;
@@ -87,9 +78,8 @@ class Extension
     {
         $responseBody = $this->getChachedResponse($extensionCode);
 
-        $url = $this->getGatewayUrl($extensionCode);
-
         if ($responseBody === false) {
+            $url = $this->getGatewayUrl($extensionCode);
             try {
                 $client = $this->httpClientFactory->create();
                 $client->setUri($url);
@@ -104,7 +94,7 @@ class Extension
             }
         }
 
-        return $this->serializer->unserialize($responseBody);
+        return json_decode($responseBody, true);
     }
 
     /**

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2018 BrainActs Commerce OÜ, All rights reserved.
+  ~ Copyright © BrainActs Commerce OÜ. All rights reserved.
   ~ See LICENSE.txt for license details.
   -->
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="BrainActs_Hub" setup_version="1.0.0">
+    <module name="BrainActs_Hub" setup_version="1.1.1">
     </module>
 </config>


### PR DESCRIPTION
Replace Magento json serialized interface with standard php json_decode for compatibility with magento version less then 2.1.9