### PR TITLE
Fixed a terribly bugged composer.json file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.idea
+/composer.lock
+.idea/
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,8 @@
   "description": "BA Hub - extension for magento 2 store that create menu for BrainActs extension and get information from BA service about installed BrainActs extension.",
   "type": "magento2-module",
   "require": {
-    "php": "~5.6.5|7.0.2|7.0.4|7.0.6|~7.0.6|~7.1.0|~7.1.3|~7.2.0"
+    "php": ">=5.6.5"
   },
-  "version": "1.1.3",
   "authors": [
     {
       "name": "BrainActs Commerce",
@@ -13,13 +12,10 @@
       "homepage": "https://www.brainacts.com/"
     }
   ],
-
   "license": "proprietary",
-  "support": [
-    {
+  "support": {
       "email": "support@brainacts.com"
-    }
-  ],
+  },
   "autoload": {
     "files": [
       "registration.php"
@@ -27,5 +23,8 @@
     "psr-4": {
       "BrainActs\\Hub\\": ""
     }
+  },
+  "require-dev": {
+    "sllh/composer-lint": "^1.0"
   }
 }


### PR DESCRIPTION
This project was flagged as one of just 30 repositories starting with `b` to have a very bugged composer.json, one that the Bettergist Collector just could not parse.

When I analyzed it, using [**`composer validate`**](https://github.com/Soullivaneuh/composer-lint), it turned out to have several issues, which I have fixed. The most major one prevented it from even working with modern composer versions.

![image](https://user-images.githubusercontent.com/1125541/57007792-e3b1b080-6bb0-11e9-81da-efea57d87493.png)

I noticed that this problem has popped up in two more PRs, so I added it to your `--dev` depedencies. In the future, run `composer validate` after modifying `composer.json`.

-----
Bettergist is a package manager for high-quality packages that meet the stringent requirements listed below. As you see, your project is pretty close to being eligible for listing.

If you would like to include your project in the Bettergist Collection it must first meet the 
following qualifications:

- [x] 1. **The project needs to be licensed.** Preferably a permissive one, like the MIT License. 
           For a helpful guide + walkthrough, see [ChooseALicense.com](https://choosealicense.com/).
    - [x] The license must be referenced in the composer.json.
    - [x] The license must be in a file called `LICENSE` or [**`LICENSE.md`**](https://github.com/IQAndreas/markdown-licenses).
- [x] 2. There needs to be documentation, preferably directly in the [**README**](https://github.com/phpexpertsinc/CSVSpeaker), following 
         the standard template (see the link). The minimum requirements for inclusion in Bettergist: 
    - [x] a. How to install via composer (`compose require vendor/package`).
    - [ ] b. How to use it (code demos). It must have at least one "```" block to be counted correctly.
- [ ] 3. **At least 50% test code coverage.** Currently, 0% coverage.

The Bettergist Collective will check your package and will automatically include it when these 
conditions of excellence are met.
